### PR TITLE
Format time from the view

### DIFF
--- a/src/components/DetailsView/index.tsx
+++ b/src/components/DetailsView/index.tsx
@@ -12,6 +12,7 @@ import {
   DetailsViewProps,
   GitHubProps,
 } from '../../types/components/DetailsView'
+import Time from '../Time'
 
 const VirtualizedList = lazy(() =>
   import('../VirtualizedList' /* webpackChunkName: "modite-virtualized-list", webpackPrefetch: true  */),
@@ -69,8 +70,7 @@ const ModiteDetail: FunctionComponent<ModiteDetailProps> = ({ className, modite 
 
           <div className={s.location}>{Location}</div>
           <div className={s.todWrap}>
-            <span className={s.tod}>{tod}</span>
-            {localDate} {localDate && localTime && '-'} {localTime}
+            <Time modite={modite} date />
           </div>
 
           <div className={s.fieldTitle}>{Title}</div>

--- a/src/components/DetailsView/styles.module.css
+++ b/src/components/DetailsView/styles.module.css
@@ -79,7 +79,7 @@
   margin-top: 8px;
 }
 
-.tod {
+.todWrap span {
   font-size: 23px;
   margin-right: 12px;
   vertical-align: middle;

--- a/src/components/MapComponent/index.tsx
+++ b/src/components/MapComponent/index.tsx
@@ -19,6 +19,8 @@ let map: MapChart
 let imageSeries: MapImageSeries
 
 const updateMap = (markerData: any) => {
+  if (imageSeries.data === markerData) return
+
   imageSeries.data = markerData
 
   if (markerData.length === 1) {
@@ -30,7 +32,7 @@ const updateMap = (markerData: any) => {
   }
 }
 
-const MapComponent = ({ mapRecords }: MapComponentProps) => {
+const MapComponent = React.memo(({ mapRecords }: MapComponentProps) => {
   const mapRef = useRef<HTMLDivElement>(null)
 
   const populateMap = (): void => {
@@ -49,7 +51,9 @@ const MapComponent = ({ mapRecords }: MapComponentProps) => {
         .filter(Boolean)
 
       if (map.isReady()) {
-        updateMap(markerData)
+        requestAnimationFrame(() => {
+          updateMap(markerData)
+        })
       } else {
         map.events.on('ready', () => {
           requestAnimationFrame(() => {
@@ -114,6 +118,6 @@ const MapComponent = ({ mapRecords }: MapComponentProps) => {
   populateMap()
 
   return <div className={`MapEl ${s.mapCt}`} ref={mapRef} />
-}
+})
 
 export default MapComponent

--- a/src/components/ModiteListItem/index.tsx
+++ b/src/components/ModiteListItem/index.tsx
@@ -7,15 +7,13 @@ import { IonIcon } from '@ionic/react'
 import Modite from '../../models/Modite'
 import { RECORD_TYPES } from '../../constants/constants'
 import ListItemProps from '../../types/components/ModiteListItem'
+import Time from '../Time'
 
 const ModiteItem = ({ modite }: { modite: Modite }) => (
   <div className={s.itemInnerCt}>
     <ModiteImage className={s.thumbContainer} modite={modite} />
     <div className={s.nameCt}>{modite.real_name}</div>
-    <div aria-hidden="true" className={s.todCt}>
-      {modite.tod}
-    </div>
-    <div className={s.localTime}>{modite.localTime}</div>
+    <Time modite={modite} />
     <IonIcon ios="ios-arrow-forward" md="ios-arrow-forward" />
   </div>
 )

--- a/src/components/ModiteListItem/styles.module.css
+++ b/src/components/ModiteListItem/styles.module.css
@@ -4,15 +4,6 @@
   justify-content: center;
 }
 
-.time {
-  flex: 0 1 4.5rem;
-  opacity: 0.75;
-}
-
-.tod {
-  flex: 0 1 1.8rem;
-}
-
 .appear {
   animation-name: appear;
   animation-fill-mode: forwards;
@@ -53,13 +44,6 @@
   text-overflow: ellipsis;
   text-align: left;
   margin-left: 6px;
-}
-
-.localTime {
-  font-size: 15px;
-  opacity: 0.5;
-  width: 78px;
-  text-align: right;
 }
 
 .projectUserCount {

--- a/src/components/Time/index.tsx
+++ b/src/components/Time/index.tsx
@@ -1,0 +1,24 @@
+import React, { FunctionComponent } from 'react'
+import { formatAMPM } from '../../service/Data'
+import Modite from '../../models/Modite'
+import s from './styles.module.css'
+
+const RawTime = ({ modite, date }: { modite: Modite; date?: boolean }) => {
+  const itemDate: Date = new Date(Date.now() - (modite.tz_offset as number) * 60000)
+  const [localTime, isAfternoon]: [string, boolean] = formatAMPM(itemDate)
+  const tod: string = isAfternoon ? '🌙' : '☀️'
+
+  return (
+    <>
+      <span aria-hidden="true">{tod}</span>
+      <time className={s.localTime} dateTime={localTime}>
+        {date ? `${modite.localDate} - ` : null}
+        {localTime}
+      </time>
+    </>
+  )
+}
+
+const Time: FunctionComponent<{ modite: Modite; date?: boolean }> = React.memo(RawTime)
+
+export default Time

--- a/src/components/Time/styles.module.css
+++ b/src/components/Time/styles.module.css
@@ -1,0 +1,6 @@
+.localTime {
+  font-size: 15px;
+  opacity: 0.5;
+  width: 78px;
+  text-align: right;
+}

--- a/src/service/Data.tsx
+++ b/src/service/Data.tsx
@@ -75,14 +75,15 @@ function monthDayYear(date: Date): string {
   return `${month} ${day}, ${year}`
 }
 
-function formatAMPM(date: Date): string {
+export function formatAMPM(date: Date): [string, boolean] {
   let hours: number = date.getHours()
   let minutes: number | string = date.getMinutes()
-  const ampm: string = hours >= 12 ? 'pm' : 'am'
+  const isAfterNoon = hours >= 12
+  const ampm: string = isAfterNoon ? 'pm' : 'am'
   hours = hours % 12
   hours = hours ? hours : 12 // the hour '0' should be '12'
   minutes = minutes < 10 ? '0' + minutes : minutes
-  return `${hours}:${minutes} ${ampm}`
+  return [`${hours}:${minutes} ${ampm}`, isAfterNoon]
 }
 
 const processTimestamps = (records: Modite[] = [], date: Date) => {
@@ -90,12 +91,8 @@ const processTimestamps = (records: Modite[] = [], date: Date) => {
 
   records.forEach((item: Modite) => {
     const itemDate: Date = new Date((nowUtc as any) - (item.tz_offset as number) * 60000)
-    const localTime: string = formatAMPM(itemDate)
-    const tod: string = localTime.includes('pm') ? '🌙' : '☀️'
 
     item.localDate = monthDayYear(itemDate)
-    item.localTime = localTime
-    item.tod = tod
   })
 }
 
@@ -235,23 +232,6 @@ const DataProvider = ({ children }: { children?: React.ReactNode }) => {
 
   useEffect((): void => {
     getData()
-
-    let minute: number
-
-    // this will run every second but only trigger
-    // the getData function when the minute changes
-    const tick = (): void => {
-      const date: Date = new Date()
-      const currentMinutes: number = date.getMinutes()
-
-      if (minute && currentMinutes !== minute) {
-        dispatch({ type: 'on-load' })
-      }
-
-      minute = currentMinutes
-    }
-
-    window.setInterval(tick, 1000)
   }, [])
 
   return <DataContext.Provider value={[state, props]}>{children}</DataContext.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9275,10 +9275,10 @@ react-virtualized-auto-sizer@1.0.2:
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
   integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
 
-react-window@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.7.1.tgz#c1db640415b97b85bc0a1c66eb82dadabca39b86"
-  integrity sha512-y4/Qc98agCtHulpeI5b6K2Hh8J7TeZIfvccBVesfqOFx4CS+TSUpnJl1/ipeXzhfvzPwvVEmaU/VosQ6O5VhTg==
+react-window@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.7.2.tgz#2e1528d5b9991e863302bfe74cb52d0ff7082e78"
+  integrity sha512-GK1gxSeGPLBDSQhPmYhCYrtf5MkGK8rwVjeyPgxZLvLRw0wvyzKZPMc/jfemiGNGfuJyW3kx1z6QR9uK7r2XdA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"


### PR DESCRIPTION
To avoid formating of the entire set, we format only from inside the view

Also, I disabled the time ticker because updating times also updates the map, which is slow and it occasionally crashes mobile Safari